### PR TITLE
Andro camera luca shutter set

### DIFF
--- a/@MIC_AndorCamera/MIC_AndorCamera.m
+++ b/@MIC_AndorCamera/MIC_AndorCamera.m
@@ -385,7 +385,7 @@ classdef MIC_AndorCamera < MIC_Camera_Abstract
                 obj.errorcheck('AndorGetStatus');
             end
             
-            % close shutter
+%             close shutter
             if ~obj.CameraSetting.ManualShutter.Bit
                 obj.closeShutter;  
             end

--- a/@MIC_AndorCamera/MIC_AndorCamera.m
+++ b/@MIC_AndorCamera/MIC_AndorCamera.m
@@ -259,9 +259,9 @@ classdef MIC_AndorCamera < MIC_Camera_Abstract
                 obj.setup_acquisition;
             end
             
-            if ~obj.CameraSetting.ManualShutter.Bit
+%             if ~obj.CameraSetting.ManualShutter.Bit
                 obj.openShutter;    
-            end
+%             end
          
             obj.setcurrentcamera();
             obj.LastError = StartAcquisition();
@@ -271,9 +271,9 @@ classdef MIC_AndorCamera < MIC_Camera_Abstract
             obj.LastError=WaitForAcquisition();
             out=obj.getdata();
           
-            if ~obj.CameraSetting.ManualShutter.Bit
+%             if ~obj.CameraSetting.ManualShutter.Bit
                 obj.closeShutter();  
-            end
+%             end
             
             if obj.KeepData
                 obj.Data=out;
@@ -353,9 +353,9 @@ classdef MIC_AndorCamera < MIC_Camera_Abstract
         function out=start_sequence(obj)
             obj.AcquisitionType='sequence';
  
-            if ~obj.CameraSetting.ManualShutter.Bit
+%             if ~obj.CameraSetting.ManualShutter.Bit
                 obj.openShutter();    
-            end
+%             end
             
             if obj.ReadyForAcq==0
                 obj.setup_acquisition();
@@ -386,9 +386,9 @@ classdef MIC_AndorCamera < MIC_Camera_Abstract
             end
             
 %             close shutter
-            if ~obj.CameraSetting.ManualShutter.Bit
+%             if ~obj.CameraSetting.ManualShutter.Bit
                 obj.closeShutter;  
-            end
+%             end
             
             if obj.AbortNow
                obj.AbortNow=0;
@@ -589,6 +589,7 @@ classdef MIC_AndorCamera < MIC_Camera_Abstract
     methods(Access=protected)
         % shutter control, internal control only...
         function openShutter(obj)
+            if isfield(obj.CameraSetting,'ManualShutter')
             extTTL = 1;
             mode = 1;
             closingtime = 50;
@@ -596,8 +597,10 @@ classdef MIC_AndorCamera < MIC_Camera_Abstract
             
             obj.LastError = SetShutter(extTTL,mode,closingtime,openingtime);
             obj.errorcheck('SetShutter');
+            end
         end
         function closeShutter(obj)
+            if isfield(obj.CameraSetting,'ManualShutter')
             extTTL = 1;
             mode = 2;
             closingtime = 50;
@@ -605,6 +608,7 @@ classdef MIC_AndorCamera < MIC_Camera_Abstract
             
             obj.LastError = SetShutter(extTTL,mode,closingtime,openingtime);
             obj.errorcheck('SetShutter');
+            end
         end
         function obj=get_capabilities(obj)
            %things with selectable modes

--- a/@MIC_GalvoDigital/MIC_GalvoDigital.m
+++ b/@MIC_GalvoDigital/MIC_GalvoDigital.m
@@ -11,7 +11,7 @@ classdef MIC_GalvoDigital < MIC_Abstract
     %  Example: obj=MIC_GalvoDigital('Dev1','Port0/Line0:31');
     %  Funtions: delete, clearSession, enable, disable, reset, setSequence,
     %  angle2word, word2angle, get.Angle, setAngle, exportState,
-    %  set.Voltage, get.Voltage, updateGui
+    %  set.Voltage, get.Voltage,G. updateGui
     %
     %  REQUIREMENTS:
     %  MIC_Abstract.m
@@ -210,8 +210,11 @@ classdef MIC_GalvoDigital < MIC_Abstract
                 msg=sprintf('Angle must be in thid Range: [%g, %g] ',-obj.Range,obj.Range);
                 error(msg);
             end
+            
+            
             TTLWord = (2^16 - 1)*(Angle+15)/(2*obj.Range);    % This step finds which of the 65,536 binary values should go to each voltage and provides the decimal number for it starting at 0 and going to 65,535.
-            Word = floor(TTLWord);        % Need to round each number to pick out one of the 65,536 values to then convert that into binary, so we need an integer here.
+            
+            Word = round(TTLWord);        % Need to round each number to pick out one of the 65,536 values to then convert that into binary, so we need an integer here.
             obj.Angle=Angle;
             obj.Word=Word;
             obj.updateGui();
@@ -248,7 +251,8 @@ classdef MIC_GalvoDigital < MIC_Abstract
             end
             
             obj.clearSession;
-            obj.Sequence=dec2bin(obj.Word, 16) - '0';
+            flip(dec2bin(obj.Word, 16) - '0')
+            obj.Sequence=flip(dec2bin(obj.Word, 16) - '0');
             obj.enable;
             outputSingleScan(obj.DAQsessionAngle,obj.Sequence);
             obj.updateGui();


### PR DESCRIPTION
Andor Camera class has been updated to work with Luca camera. The changes made are:
1) Remove if statement checking CameraSetting.ManualShutter.Bit before openShutter and closeShutter functions in start_sequence and start_capture
2) Include check for ManualShutter field in CameraSetting in openShutter and closeShutter functions.

This makes the class compatible with Luca for start_sequence and start_capture.