### PR TITLE
Create h5 reader method mic h5

### DIFF
--- a/MIC_H5.m
+++ b/MIC_H5.m
@@ -13,6 +13,7 @@ classdef MIC_H5
     %
     % REQUIRES:
     %   h5Write_Async.mex64
+    %   MATLAB 2011a or newer
     
     properties
     end
@@ -61,7 +62,89 @@ classdef MIC_H5
             H5F.close(fid);
         end
         
-        
+        function [H5Structure] = readH5File(FilePath, GroupName)
+        %Extracts contents of an h5 file into H5Structure.
+        % This method will extract the Data and Attributes from a group
+        % named GroupName in the .h5 file specified by FilePath.  
+        % Examples: 
+        %   H5Structure = readH5File('C:\file.h5', 'Laser647') will extract
+        %       contents of the group 'Laser647' from file.h5
+
+            % Ensure that FilePath points to a valid file.
+            % NOTE: == 2 means a file indeed exists at FilePath
+            if exist(FilePath, 'file') ~= 2
+                error(['File specified by FilePath = ', ...
+                    '''%s'' does not exist.'], FilePath)
+            end
+
+            % Read in all of the information available in the h5 file using 
+            % MATLAB's built-in h5info() method.
+            H5Info = h5info(FilePath); 
+
+            % Iterate through the structure provided by h5info() to find 
+            % the fields specified by GroupName.
+            CurrentGroups = H5Info.Groups; % current groups to be explored
+            CurrentGroupNames = {CurrentGroups.Name};
+            GroupFound = 0; % boolean 0: group not found, 1: group found
+            while ~GroupFound
+                % Iterate through each of CurrentGroups to search for the 
+                % desired group.
+                for ii = 1:numel(CurrentGroupNames)
+                    % Simplify the group name to remove group structure, 
+                    % e.g. if 
+                    % CurrentGroupNames{ii} = '/Channel01/Zposition001', 
+                    % simplify it to 'ZPosition001' for comparison to 
+                    % GroupName.
+                    LastSlashIndex = find(CurrentGroupNames{ii}=='/', ...
+                        1, 'last'); 
+                    CurrentGroupName = ...
+                        CurrentGroupNames{ii}(LastSlashIndex+1:end);
+
+                    % Check if the current group is the desired group, 
+                    % breaking out of the for loop if it is.
+                    if strcmp(CurrentGroupName, GroupName)
+                        GroupFound = 1;
+                        break; % exit the current for loop immediately
+                    end
+                end
+
+                % If the group has not been found yet, move one level 
+                % deeper into the structure.
+                if ~GroupFound
+                    try
+                        % Attempt to move one level deeper into the 
+                        % structure.
+                        CurrentGroups = CurrentGroups.Groups;
+                        CurrentGroupNames = {CurrentGroups.Name};
+                    catch
+                        % We've reached the end of the structure, there are 
+                        % no more groups to explore.
+                        error(['No group named ''%s'' was found in ', ...
+                            'the file specified by FilePath = ''%s'''], ...
+                            GroupName, FilePath)
+                    end
+                end
+            end
+
+            % Now that we've found the desired group, store it's Data and 
+            % Attributes in a more useable format.
+            % NOTE: to reach this point in the code, we have found the 
+            % desired group and it will have been found on the last 
+            % iteration of the above for loop, thus the ii-th index will be
+            % the index of the desired Group in the CurrentGroups cell 
+            % array.
+            DesiredGroup = CurrentGroups(ii); 
+            H5Structure.Attributes = DesiredGroup.Attributes;
+            for ii = 1:numel(DesiredGroup.Datasets)
+                % Read the ii-th dataset from the h5 file and store the 
+                % data in a field of the output structure, matching the 
+                % datasets name in the h5 file to the name of the field in 
+                % the output structure.
+                H5Structure.(DesiredGroup.Datasets(ii).Name) = ...
+                    h5read(FilePath, [DesiredGroup.Name, '/', ...
+                        DesiredGroup.Datasets(ii).Name]);
+            end
+        end
         
         
     end

--- a/MIC_H5.m
+++ b/MIC_H5.m
@@ -67,18 +67,33 @@ classdef MIC_H5
         % This method will extract the Data and Attributes from a group
         % named GroupName in the .h5 file specified by FilePath.  
         % Examples: 
+        %   H5Structure = readH5File('C:\file.h5') will extract all 
+        %       contents of file.h5 and store them in H5Structure.
         %   H5Structure = readH5File('C:\file.h5', 'Laser647') will extract
-        %       contents of the group 'Laser647' from file.h5 given only the group
-        %       name.
+        %       contents of the group 'Laser647' from file.h5 given only 
+        %       the group name.
         %   H5Structure = readH5File('C:\file.h5', ...
-        %       '/Channel01/Zposition001/Laser647') will extract contents of the
-        %       group 'Laser647' from file.h5 given a full group path.
+        %       '/Channel01/Zposition001/Laser647') will extract contents 
+        %       of the group 'Laser647' from file.h5 given a full group 
+        %       path.
+        %
+        % CITATION: David Schodt, Lidke Lab, 2018
 
             % Ensure that FilePath points to a valid file.
             % NOTE: == 2 means a file indeed exists at FilePath
             if exist(FilePath, 'file') ~= 2
                 error(['File specified by FilePath = ', ...
                     '''%s'' does not exist.'], FilePath)
+            end
+
+            % If GroupName was not specified, set a flag to indicate we 
+            % want to extract all contents from the .h5 file.
+            if exist('GroupName', 'var')
+                % Groupname was given, don't set the SaveAll flag.
+                SaveAll = 0;
+            else
+                % GroupName was not given, set the SaveAll flag. 
+                SaveAll = 1; 
             end
 
             % Read in all of the information available in the h5 file using 
@@ -89,41 +104,52 @@ classdef MIC_H5
             % the fields specified by GroupName.
             CurrentGroups = H5Info.Groups; % current groups to be explored
             CurrentGroupNames = {CurrentGroups.Name};
-            GroupFound = 0; % boolean 0: group not found, 1: group found
-            while ~GroupFound
+            DesiredGroups = []; % empty to initialize the while loop
+            while isempty(DesiredGroups)
+                % If we are extracting all contents in the .h5 file at
+                % FilePath, we don't want to perform the search procedure 
+                % in this while loop.  Set DesiredGroups to CurrentGroups 
+                % (all of the groups found in the .h5 file) and break out 
+                % of the loop.
+                if SaveAll
+                    DesiredGroups = CurrentGroups;
+                    break
+                end
+
                 % Iterate through each of CurrentGroups to search for the 
                 % desired group.
-                for ii = 1:numel(CurrentGroupNames)
-                    % If the GroupName isn't provided as a full path, simplify
-                    % the current group name to remove group structure e.g. if 
+                for jj = 1:numel(CurrentGroupNames)
+                    % If the GroupName isn't provided as a full path, 
+                    % simplify the current group name to remove group 
+                    % structure e.g. if 
                     % CurrentGroupNames{ii} = '/Channel01/Zposition001', 
                     % simplify it to 'ZPosition001' for comparison to 
                     % GroupName.
                     if GroupName(1) == '/'
-                        % If the first character of the input GroupName is '/',
-                        % assume that a full path was provided to the desired
-                        % group.
-                        CurrentGroupName = CurrentGroupNames{ii}; 
+                        % If the first character of the input GroupName is 
+                        % '/', assume that a full path was provided to the 
+                        % desired group.
+                        CurrentGroupName = CurrentGroupNames{jj}; 
                     else
-                        % The full path was not given, just a raw group name was
-                        % given.
-                        LastSlashIndex = find(CurrentGroupNames{ii}=='/', ...
-                            1, 'last'); 
+                        % The full path was not given, just a raw group 
+                        % name was given.
+                        LastSlashIndex = ...
+                            find(CurrentGroupNames{jj}=='/', 1, 'last'); 
                         CurrentGroupName = ...
-                            CurrentGroupNames{ii}(LastSlashIndex+1:end);
+                            CurrentGroupNames{jj}(LastSlashIndex+1:end);
                     end
 
                     % Check if the current group is the desired group, 
                     % breaking out of the for loop if it is.
                     if strcmp(CurrentGroupName, GroupName)
-                        GroupFound = 1;
+                        DesiredGroups = CurrentGroups(jj);
                         break; % exit the current for loop immediately
                     end
                 end
 
                 % If the group has not been found yet, move one level 
                 % deeper into the structure.
-                if ~GroupFound
+                if isempty(DesiredGroups)
                     try
                         % Attempt to move one level deeper into the 
                         % structure.
@@ -139,71 +165,87 @@ classdef MIC_H5
                 end
             end
 
-            % Now that we've found the desired group, store it's Attributes, 
-            % Data, and Children in a more useable format.
-            % NOTE: to reach this point in the code, we have found the 
-            % desired group and it will have been found on the last 
-            % iteration of the above for loop, thus the ii-th index will be
-            % the index of the desired Group in the CurrentGroups cell 
-            % array.
-            DesiredGroup = CurrentGroups(ii);
-            if ~isempty(DesiredGroup.Attributes)
-                % If the desired group has attributes, store them in the output
-                % structure.
-                for ii = 1:numel(DesiredGroup.Attributes)
-                    % Store each attribute as a field in the output structure
-                    % accesible directly by that attributes name.
-                    AttributeName = DesiredGroup.Attributes(ii).Name;
-                    H5Structure.Attributes.(AttributeName) = ...
-                        DesiredGroup.Attributes(ii).Value;
-                end
-            else
-                % Create an empty field for the Attributes to prevent issues with
-                % functions that may be using this method.
-                H5Structure.Attributes = [];
-            end
-            if ~isempty(DesiredGroup.Datasets)
-                for ii = 1:numel(DesiredGroup.Datasets)
-                    % Read the ii-th dataset from the h5 file and store the 
-                    % data in a field of the output structure, matching the 
-                    % datasets name in the h5 file to the name of the field in 
-                    % the output structure.
-                    H5Structure.Data.(DesiredGroup.Datasets(ii).Name) = ...
-                        h5read(FilePath, [DesiredGroup.Name, '/', ...
-                            DesiredGroup.Datasets(ii).Name]);
-                end
-            else
-                % Create an empty field for the Data to prevent issues with
-                % functions that may be using this method.
-                H5Structure.Data = [];
-            end
-            if ~isempty(DesiredGroup.Groups)
-                % Create a cell array of subgroup names (if subgroups exist).
-                % NOTE: If you are comparing the output structure to the Data,
-                % Attributes, and Children format used in the exportState() method,
-                % the subgroups are assumed to be the Children.
-                SubgroupNames = {DesiredGroup.Groups.Name};
-                for ii = 1:numel(SubgroupNames)
-                    % Iteratively explore subgroups of the desired group to
-                    % store their attributes and data.
-                    SubgroupStructure = h5reader_test(FilePath, ...
-                        SubgroupNames{ii});
+            % Now that we've found the desired group(s), store the
+            % Attributes, Data, and Children in a more useable format.
+            for ii = 1:numel(DesiredGroups)
+                % Set DesiredGroup = DesiredGroups(ii) to reduce indexing 
+                % clutter/improve code readability.
+                DesiredGroup = DesiredGroups(ii); 
 
-                    % Remove the path information from the subgroup name, e.g. 
-                    % /Channel01/Zposition001 will become Zposition001.
-                    LastSlashIndex = find(SubgroupNames{ii}=='/', ...
-                            1, 'last');
-                    SubgroupName = SubgroupNames{ii}(LastSlashIndex+1:end); 
-
-                    % Store the subgroup structure into the output H5Structure.
-                    H5Structure.Children.(SubgroupName) = SubgroupStructure;
+                % If the desired group has attributes, store them in the 
+                % output structure.
+                if ~isempty(DesiredGroup.Attributes)
+                    for jj = 1:numel(DesiredGroup.Attributes)
+                        % Store each attribute as a field in the output 
+                        % structure accesible directly by that attributes 
+                        % name.
+                        AttributeName = DesiredGroup.Attributes(jj).Name;
+                        H5Structure.Attributes.(AttributeName) = ...
+                            DesiredGroup.Attributes(jj).Value;
+                    end
+                else
+                    % Create an empty field for the Attributes to prevent 
+                    % issues with functions that may be using this method.
+                    H5Structure.Attributes = [];
                 end
-            else
-                % Create an empty field for the Children to prevent issues with
-                % functions that may be using this method.
-                H5Structure.Children = [];
+
+                % If the desired group has data, store the data in the 
+                % output structure.
+                if ~isempty(DesiredGroup.Datasets)
+                    for jj = 1:numel(DesiredGroup.Datasets)
+                        % Read the ii-th dataset from the h5 file and store 
+                        % the data in a field of the output structure, 
+                        % matching the datasets name in the h5 file to the 
+                        % name of the field in the output structure.
+                        DatasetName = DesiredGroup.Datasets(jj).Name;
+                        H5Structure.Data.(DatasetName) = ...
+                            h5read(FilePath, [DesiredGroup.Name, '/', ...
+                                DesiredGroup.Datasets(jj).Name]);
+                    end
+                else
+                    % Create an empty field for the Data to prevent issues
+                    % with functions that may be using this method.
+                    H5Structure.Data = [];
+                end
+
+                % If the desired group has Children (subgroups), recurse 
+                % through those to store their Attributes, Data, and 
+                % Children.
+                if ~isempty(DesiredGroup.Groups)
+                    % Create a cell array of subgroup names (if subgroups 
+                    % exist).
+                    % NOTE: If you are comparing the output structure to 
+                    % the Data, Attributes, and Children format used in the 
+                    % exportState() method, the subgroups are assumed to be 
+                    % the Children.
+                    SubgroupNames = {DesiredGroup.Groups.Name};
+                    for jj = 1:numel(SubgroupNames)
+                        % Iteratively explore subgroups of the desired 
+                        % group to store their attributes and data.
+                        SubgroupStructure = h5reader_test(FilePath, ...
+                            SubgroupNames{jj});
+
+                        % Remove the path information from the subgroup 
+                        % name, e.g. /Channel01/Zposition001 will become 
+                        % Zposition001.
+                        LastSlashIndex = find(SubgroupNames{jj}=='/', ...
+                                1, 'last');
+                        SubgroupName = ...
+                            SubgroupNames{jj}(LastSlashIndex+1:end); 
+
+                        % Store the subgroup structure into the output 
+                        % H5Structure.
+                        H5Structure.Children.(SubgroupName) = ...
+                            SubgroupStructure;
+                    end
+                else
+                    % Create an empty field for the Children to prevent 
+                    % issues with functions that may be using this method.
+                    H5Structure.Children = [];
+                end
             end
         end
+        
     end
     
 end


### PR DESCRIPTION
This branch will add a static method to the class MIC_H5 called MIC_H5.readH5File(...), which can be used to extract the contents of an h5 file.  I've tested this method on .h5 files generated on both the sequential and the TIRF microscopes.