### PR TITLE
Fix call to a non-existent function in MIC_H5.readH5File()

### DIFF
--- a/MIC_H5.m
+++ b/MIC_H5.m
@@ -222,7 +222,7 @@ classdef MIC_H5
                     for jj = 1:numel(SubgroupNames)
                         % Iteratively explore subgroups of the desired 
                         % group to store their attributes and data.
-                        SubgroupStructure = h5reader_test(FilePath, ...
+                        SubgroupStructure = MIC_H5.readH5File(FilePath, ...
                             SubgroupNames{jj});
 
                         % Remove the path information from the subgroup 


### PR DESCRIPTION
This branch replaces a call to h5reader_test (which is local to one machine) with the appropriate iterative call to MIC_H5.readH5File() inside of the method MIC_H5.readH5File().  I've tested this fix on both my main computer and the computer controlling the sequential microscope and it was observed to work on both machines.