### PR TITLE
Fix bug that was causing autoName to produce invalid variable names

### DIFF
--- a/@MIC_Abstract/MIC_Abstract.m
+++ b/@MIC_Abstract/MIC_Abstract.m
@@ -60,8 +60,9 @@ classdef MIC_Abstract < handle
             % rewritten in the workspace and cause many problems. Technically speaking:  
             % Automatically names this object to a top-level workspace variable with a new unused name based on the
             % obects InstrumentName.
-            curVars = evalin('base',sprintf('who(''%s*'');',obj.InstrumentName));
-            varPattern = sprintf('%s%%i',obj.InstrumentName);
+            tInstrumentName = regexprep(obj.InstrumentName,'[\W]+','');
+            curVars = evalin('base',sprintf('who(''%s*'');',tInstrumentName));
+            varPattern = sprintf('%s%%i', tInstrumentName);
             varName = MIC_Abstract.nextUnusedName(curVars,varPattern);
             assignin('base',varName,obj);
             fprintf('Assigned new %s object as variable "%s"\n',obj.InstrumentName, varName);
@@ -169,8 +170,8 @@ classdef MIC_Abstract < handle
             if isempty(Data)
                 %h5create(File,['/' Group],1);
             else
-                Data_Names = fieldnames(Data)
-                NData=length(Data_Names)
+                Data_Names = fieldnames(Data);
+                NData=length(Data_Names);
                 
                 for nn=1:NData
                     h5create(File,['/' Group '/' Data_Names{nn}],size(Data.(Data_Names{nn})));

--- a/@MIC_PM100D/MIC_PM100D.m
+++ b/@MIC_PM100D/MIC_PM100D.m
@@ -114,6 +114,7 @@ classdef MIC_PM100D < MIC_PowerMeter_Abstract
             obj.Lambda=str2double(send(obj,'CORRECTION:WAVELENGTH?'));
             fprintf('Wavelength: %d nm \n',obj.Lambda);
         end
+
         function Out=measure(obj)
             %This either measures the power or temperature.
             switch obj.Ask
@@ -121,8 +122,17 @@ classdef MIC_PM100D < MIC_PowerMeter_Abstract
                     Out=str2double(send(obj,'MEASURE:POWER?'))*1000;
                 case 'temp'
                     Out=str2double(send(obj,'MEASURE:TEMPERATURE?'));
-            end 
+            end
         end
+
+        function out=measurePower(obj)
+            % Measure power
+            out=str2double(send(obj,'MEASURE:POWER?'))*1000;
+        end
+
+        function out=measureTemperature(obj)
+            % Measure temperature
+            out=str2double(send(obj,'MEASURE:TEMPERATURE?'));
         end
 
         function setWavelength(obj,lambda)

--- a/@MIC_PM100D/MIC_PM100D.m
+++ b/@MIC_PM100D/MIC_PM100D.m
@@ -3,9 +3,9 @@ classdef MIC_PM100D < MIC_PowerMeter_Abstract
     %
     % ## Description
     % Controls power meter PM100D, gets the current power. It can also gets
-    % the current temperature. The wavelenght of the light can also be
-    % set for power measurement, where the range of the wavelength is
-    % 400nm < Lambda < 1100nm. The gui shows a movie of the plot of the
+    % the current temperature. The wavelengtj of the light can also be
+    % set for power measurement (within the sensor limits). The gui shows 
+    % a movie of the plot of the
     % measured power where the shown period can be modified. It also shows
     % the current power and the maximum measured power. To run this code
     % you need the power meter to be connected to the machine.
@@ -144,8 +144,10 @@ classdef MIC_PM100D < MIC_PowerMeter_Abstract
             %
             %
             if nargin>1
-                if (lambda < 400 || lambda > 1100)
-                   error('The wavelength is out of the range [400nm, 1100nm].');
+                if (lambda < obj.Limits(1) || lambda > obj.Limits(2))
+                   fprintf('The wavelength is out of the range [%dnm, %dnm]\n', ...
+                       obj.Limits);
+                   return
                 else
                     obj.Lambda = lambda;
                 end

--- a/@MIC_PM100D/MIC_PM100D.m
+++ b/@MIC_PM100D/MIC_PM100D.m
@@ -1,4 +1,4 @@
-classdef MIC_PM100D < MIC_PowerMeter_Abstract 
+classdef MIC_PM100D < MIC_PowerMeter_Abstract
     % MIC_PM100D: Matlab Instrument class to control power meter PM100D.
     %
     % ## Description
@@ -7,13 +7,13 @@ classdef MIC_PM100D < MIC_PowerMeter_Abstract
     % set for power measurement, where the range of the wavelength is
     % 400nm < Lambda < 1100nm. The gui shows a movie of the plot of the
     % measured power where the shown period can be modified. It also shows
-    % the current power and the maximum measured power. To run this code 
+    % the current power and the maximum measured power. To run this code
     % you need the power meter to be connected to the machine.
     %
     % ## Constructor
     % Example: P = MIC_PM100D; P.gui
     %
-    % ## Key Functions: 
+    % ## Key Functions:
     % constructor(), exportState(), send(), minMaxWavelength(), getWavelength(), measure(), setWavelength(), shutdown()
     %
     % ## REQUIREMENTS:
@@ -23,24 +23,26 @@ classdef MIC_PM100D < MIC_PowerMeter_Abstract
     %    MIC_PowerMeter_Abstract.m
     %
     % ### CITATION: Mohamadreza Fazel, Lidkelab, 2017.
-    
+
     properties (SetAccess=protected)
         InstrumentName='PM100D'; %Name of the instrument.
     end
+
+
     methods (Static)
         function obj=MIC_PM100D
             %This is the constructor.
             %example PM = MIC_PM100D
-            obj@MIC_PowerMeter_Abstract(~nargout);    
-           
+            obj@MIC_PowerMeter_Abstract(~nargout);
+
             % Find a VISA-USB object.
             vendorinfo = instrhwinfo('visa','ni');
             s=vendorinfo.ObjectConstructorName{1};
-            
+
             if isempty(obj.VisaObj)
                 obj.VisaObj = eval(s);
             else
-                
+
                 fclose(obj.VisaObj);
                 clear obj.VisaObj;
                 obj.VisaObj = eval(s);
@@ -49,59 +51,62 @@ classdef MIC_PM100D < MIC_PowerMeter_Abstract
             fopen(obj.VisaObj);
             % Measure the limits of the wavelength.
             obj.Limits=minMaxWavelength(obj);
-        end 
-      function unitTest()
-          %testing the class.
-          try
-          TestObj=MIC_PM100D();
-          fprintf('Constructor is run and an object of the class is made.\n');
-          Limit = minMaxWavelength(TestObj);
-          fprintf('Min wavelength: %d, Max wavelength: %d\n', Limit(1),Limit(2));
-          getWavelength(TestObj);
-          fprintf('The current wavelength is %d nm.\n',TestObj.Lambda);
-          TestObj.Lambda=600;
-          setWavelength(TestObj);
-          fprintf('The wavelength is set to 600 nm.\n');
-          State=exportState(TestObj);
-          fprintf('The exportState function was successfully tested.\n');
-          TestObj.delete();
-          fprintf('The port is closed and the object is deleted.\n');
-          fprintf('The class is successfully tested :)\n')
-          catch E
-             fprintf('Sorry an error has ocured :(\n'); 
-              E
-          end
-      end
-    end
-    
+
+            obj.Ask = 'power'; % by default we read power
+        end %constructor
+
+        function unitTest()
+            %testing the class.
+            try
+                TestObj=MIC_PM100D();
+                fprintf('Constructor is run and an object of the class is made.\n');
+                Limit = minMaxWavelength(TestObj);
+                fprintf('Min wavelength: %d, Max wavelength: %d\n', Limit(1),Limit(2));
+                getWavelength(TestObj);
+                fprintf('The current wavelength is %d nm.\n',TestObj.Lambda);
+                TestObj.Lambda=600;
+                setWavelength(TestObj);
+                fprintf('The wavelength is set to 600 nm.\n');
+                State=exportState(TestObj);
+                fprintf('The exportState function was successfully tested.\n');
+                TestObj.delete();
+                fprintf('The port is closed and the object is deleted.\n');
+                fprintf('The class is successfully tested :)\n')
+            catch E
+                fprintf('Sorry an error has ocured :(\n');
+                E
+            end
+        end % unitTest
+
+    end %static methods
+
     methods
-        
+
         function  State=exportState(obj)
             %Exporting the class properties to the State.
             State.InstrunetName=obj.InstrumentName;
             State.Lambda=obj.Lambda;
             State.Limits=obj.Limits;
         end
-        
+
         function Reply=send(obj,Message)
             %Sending a message to the power-meter and getting a feedback.
             fprintf(obj.VisaObj,Message);
             Reply=fscanf(obj.VisaObj,'%s');
         end
-        
+
         function Limits=minMaxWavelength(obj)
             %Reading the limits of the wavelength.
             R1=obj.send('CORRECTION:WAVELENGTH? MIN');
             R2=obj.send('CORRECTION:WAVELENGTH? MAX');
             Limits = [str2double(R1) str2double(R2)];
         end
-        
+
         function getWavelength(obj)
             %Reading the current wavelength of the instrument.
             obj.Lambda=str2double(send(obj,'CORRECTION:WAVELENGTH?'));
             fprintf('Wavelength: %d nm \n',obj.Lambda);
         end
-        
         function Out=measure(obj)
             %This either measures the power or temperature.
             switch obj.Ask

--- a/@MIC_PM100D/MIC_PM100D.m
+++ b/@MIC_PM100D/MIC_PM100D.m
@@ -80,7 +80,7 @@ classdef MIC_PM100D < MIC_PowerMeter_Abstract
                 fprintf('The port is closed and the object is deleted.\n');
                 fprintf('The class is successfully tested :)\n')
             catch E
-                fprintf('Sorry an error has ocured :(\n');
+                fprintf('Sorry an error has occurred :(\n');
                 E
             end
         end % unitTest
@@ -119,20 +119,20 @@ classdef MIC_PM100D < MIC_PowerMeter_Abstract
             %This either measures the power or temperature.
             switch obj.Ask
                 case 'power'
-                    Out=str2double(send(obj,'MEASURE:POWER?'))*1000;
+                    Out=str2double(obj.send('MEASURE:POWER?'))*1000;
                 case 'temp'
-                    Out=str2double(send(obj,'MEASURE:TEMPERATURE?'));
+                    Out=str2double(obj.send('MEASURE:TEMPERATURE?'));
             end
         end
 
         function out=measurePower(obj)
             % Measure power
-            out=str2double(send(obj,'MEASURE:POWER?'))*1000;
+            out=str2double(obj.send('MEASURE:POWER?'))*1000;
         end
 
         function out=measureTemperature(obj)
             % Measure temperature
-            out=str2double(send(obj,'MEASURE:TEMPERATURE?'));
+            out=str2double(obj.send('MEASURE:TEMPERATURE?'));
         end
 
         function setWavelength(obj,lambda)

--- a/@MIC_PM100D/MIC_PM100D.m
+++ b/@MIC_PM100D/MIC_PM100D.m
@@ -137,12 +137,12 @@ classdef MIC_PM100D < MIC_PowerMeter_Abstract
             %This function is called in the destructor to delete the communication port.
             fclose(obj.VisaObj);
         end
-     function delete(obj)
-         %This function close the comunication port and close the gui.
-        delete(obj.GuiFigure);
-        obj.shutdown(); 
-        clear obj;
-     end
-      
-   end
-end
+        function delete(obj)
+            %This function closes the communication port and close the gui.
+           delete(obj.GuiFigure);
+           obj.shutdown();
+        end % delete
+
+   end % methods
+
+end % classdef

--- a/@MIC_PM100D/MIC_PM100D.m
+++ b/@MIC_PM100D/MIC_PM100D.m
@@ -44,21 +44,17 @@ classdef MIC_PM100D < MIC_PowerMeter_Abstract
                 return
             end
 
+            % Use the constructor command to connect to the device.
             s=vendorinfo.ObjectConstructorName{1};
-
-            if isempty(obj.VisaObj)
-                obj.VisaObj = eval(s);
-            else
-
-                fclose(obj.VisaObj);
-                clear obj.VisaObj;
-                obj.VisaObj = eval(s);
-            end
-            % Connect to instrument object
+            obj.VisaObj = eval(s);
             fopen(obj.VisaObj);
+            
             % Measure the limits of the wavelength.
             obj.Limits=minMaxWavelength(obj);
 
+            % TODO: this process of using the "Ask" property to determine
+            % whether to read light power or temperature is very weird 
+            % and should be removed. 
             obj.Ask = 'power'; % by default we read power
         end %constructor
 

--- a/@MIC_PM100D/MIC_PM100D.m
+++ b/@MIC_PM100D/MIC_PM100D.m
@@ -95,6 +95,7 @@ classdef MIC_PM100D < MIC_PowerMeter_Abstract
 
         function Reply=send(obj,Message)
             %Sending a message to the power-meter and getting a feedback.
+
             fprintf(obj.VisaObj,Message);
             Reply=fscanf(obj.VisaObj,'%s');
         end
@@ -115,6 +116,25 @@ classdef MIC_PM100D < MIC_PowerMeter_Abstract
             autoRange = str2num(autoRange);
         end
 
+        function disableAutoRange(obj)
+            % Disable auto-range
+            fprintf(obj.VisaObj,'SENSE:POWER:RANGE:AUTO OFF');
+        end
+      
+        function enableAutoRange(obj)
+            % Enable auto-range
+            fprintf(obj.VisaObj,'SENSE:POWER:RANGE:AUTO ON');
+        end
+
+        function setAutoRange(obj,autoRange)
+            % Set auto-range. 
+            % autoRange is a string (TODO: for now)
+            %
+            % e.g.
+            % setAutoRange('0.1')
+            fprintf(obj.VisaObj,sprintf('SENSE:POWER:RANGE %s',autoRange));
+        end
+      
         function Limits=minMaxWavelength(obj)
             %Reading the limits of the wavelength.
             %

--- a/@MIC_PM100D/MIC_PM100D.m
+++ b/@MIC_PM100D/MIC_PM100D.m
@@ -99,6 +99,22 @@ classdef MIC_PM100D < MIC_PowerMeter_Abstract
             Reply=fscanf(obj.VisaObj,'%s');
         end
 
+        function devInfo = reportDeviceInfo(obj)
+            % Return string describing the model number, etc, of the power meter
+            devInfo = obj.send('*IDN?');
+        end
+
+        function devInfo = reportSensorInfo(obj)
+            % Return string describing the sensor head
+            devInfo = obj.send(':SYST:SENS:IDN?');
+        end
+
+        function autoRange = isAutoRangeEnabled(obj)
+            % Return 1 if autorange is enabled. 0 otherwise
+            autoRange = obj.send(':SENS:POWER:RANG:AUTO?');
+            autoRange = str2num(autoRange);
+        end
+
         function Limits=minMaxWavelength(obj)
             %Reading the limits of the wavelength.
             %

--- a/@MIC_PM100D/MIC_PM100D.m
+++ b/@MIC_PM100D/MIC_PM100D.m
@@ -48,9 +48,9 @@ classdef MIC_PM100D < MIC_PowerMeter_Abstract
             s=vendorinfo.ObjectConstructorName{1};
             obj.VisaObj = eval(s);
             fopen(obj.VisaObj);
-            
+
             % Measure the limits of the wavelength.
-            obj.Limits=minMaxWavelength(obj);
+            obj.Limits=obj.minMaxWavelength;
 
             % TODO: this process of using the "Ask" property to determine
             % whether to read light power or temperature is very weird 

--- a/@MIC_PM100D/MIC_PM100D.m
+++ b/@MIC_PM100D/MIC_PM100D.m
@@ -36,7 +36,14 @@ classdef MIC_PM100D < MIC_PowerMeter_Abstract
             obj@MIC_PowerMeter_Abstract(~nargout);
 
             % Find a VISA-USB object.
+            % TODO -- the following commands to find the device assume
+            % only one device is connected
             vendorinfo = instrhwinfo('visa','ni');
+            if isempty(vendorinfo.ObjectConstructorName)
+                fprintf('No devices found\n')
+                return
+            end
+
             s=vendorinfo.ObjectConstructorName{1};
 
             if isempty(obj.VisaObj)

--- a/@MIC_PM100D/MIC_PM100D.m
+++ b/@MIC_PM100D/MIC_PM100D.m
@@ -123,20 +123,36 @@ classdef MIC_PM100D < MIC_PowerMeter_Abstract
                     Out=str2double(send(obj,'MEASURE:TEMPERATURE?'));
             end 
         end
-     
-     function setWavelength(obj)
-         %setting the wavelength 
-         if obj.Lambda < 400 || obj.Lambda > 1100
-             error('The wavelength is out of the range [400nm, 1100nm].');
-         end
-             
-         s = sprintf('CORRECTION:WAVELENGTH %g nm',obj.Lambda);
-         fprintf(obj.VisaObj, s);
-     end
-     function shutdown(obj)
-            %This function is called in the destructor to delete the communication port.
-            fclose(obj.VisaObj);
         end
+
+        function setWavelength(obj,lambda)
+            % Setting the compensation wavelength
+            %
+            % serWavelength(lambda)
+            %
+            % Inputs
+            % lambda [optional] - scalar in nm between 400 and 1100
+            %      If lambda is not supplied, the value in the class Lambda
+            %      property is used instead. If it is supplied, the Lambda
+            %      property is assigned as lambda.
+            %
+            %
+            if nargin>1
+                if (lambda < 400 || lambda > 1100)
+                   error('The wavelength is out of the range [400nm, 1100nm].');
+                else
+                    obj.Lambda = lambda;
+                end
+            end
+            s = sprintf('CORRECTION:WAVELENGTH %g nm',obj.Lambda);
+            fprintf(obj.VisaObj, s);
+        end % setWavelength
+
+        function shutdown(obj)
+               %This function is called in the destructor to delete the communication port.
+               fclose(obj.VisaObj);
+        end % shutdown
+
         function delete(obj)
             %This function closes the communication port and close the gui.
            delete(obj.GuiFigure);

--- a/@MIC_PM100D/MIC_PM100D.m
+++ b/@MIC_PM100D/MIC_PM100D.m
@@ -197,6 +197,9 @@ classdef MIC_PM100D < MIC_PowerMeter_Abstract
 
         function shutdown(obj)
                %This function is called in the destructor to delete the communication port.
+               if isempty(obj.VisaObj)
+                   return
+               end
                fclose(obj.VisaObj);
         end % shutdown
 

--- a/@MIC_PM100D/MIC_PM100D.m
+++ b/@MIC_PM100D/MIC_PM100D.m
@@ -48,6 +48,7 @@ classdef MIC_PM100D < MIC_PowerMeter_Abstract
             s=vendorinfo.ObjectConstructorName{1};
             obj.VisaObj = eval(s);
             fopen(obj.VisaObj);
+            fprintf('Connected to VISA power meter device\n')
 
             % Measure the limits of the wavelength.
             obj.Limits=obj.minMaxWavelength;
@@ -100,14 +101,15 @@ classdef MIC_PM100D < MIC_PowerMeter_Abstract
 
         function Limits=minMaxWavelength(obj)
             %Reading the limits of the wavelength.
-            R1=obj.send('CORRECTION:WAVELENGTH? MIN');
-            R2=obj.send('CORRECTION:WAVELENGTH? MAX');
+            %
+            R1=obj.send('SENS:CORR:WAV? MIN');
+            R2=obj.send('SENS:CORR:WAV? MAX');
             Limits = [str2double(R1) str2double(R2)];
         end
 
         function getWavelength(obj)
             %Reading the current wavelength of the instrument.
-            obj.Lambda=str2double(send(obj,'CORRECTION:WAVELENGTH?'));
+            obj.Lambda=str2double(send(obj,'SENS:CORR:WAV?'));
             fprintf('Wavelength: %d nm \n',obj.Lambda);
         end
 
@@ -143,6 +145,7 @@ classdef MIC_PM100D < MIC_PowerMeter_Abstract
             %      property is assigned as lambda.
             %
             %
+           
             if nargin>1
                 if (lambda < obj.Limits(1) || lambda > obj.Limits(2))
                    fprintf('The wavelength is out of the range [%dnm, %dnm]\n', ...
@@ -152,7 +155,7 @@ classdef MIC_PM100D < MIC_PowerMeter_Abstract
                     obj.Lambda = lambda;
                 end
             end
-            s = sprintf('CORRECTION:WAVELENGTH %g nm',obj.Lambda);
+            s = sprintf('SENS:CORR:WAV %g ',obj.Lambda);
             fprintf(obj.VisaObj, s);
         end % setWavelength
 

--- a/@MIC_PM100D/Readme.md
+++ b/@MIC_PM100D/Readme.md
@@ -1,25 +1,32 @@
 # MIC_PM100D: Matlab Instrument class to control power meter PM100D.
 
 ## Description
-Controls power meter PM100D, gets the current power. It can also gets
-the current temperature. The wavelenght of the light can also be
-set for power measurement, where the range of the wavelength is
-400nm < Lambda < 1100nm. The gui shows a movie of the plot of the
+Controls the [ThorLabs PM100D](https://www.thorlabs.com/newgrouppage9.cfm?objectgroup_id=3341&pn=PM100D) light power meter.
+The class can retrieve the current power and current temperature. 
+The wavelenghth of the light can be set programatically, as can the wavelength (within the 400 nm to 1100 nm range).
+The gui shows a movie of the plot of the
 measured power where the shown period can be modified. It also shows
 the current power and the maximum measured power. To run this code
 you need the power meter to be connected to the machine.
 
 ## Constructor
-Example: P = MIC_PM100D; P.gui
+Example: 
+
+```matlab
+P = MIC_PM100D; 
+P.gui
+P.measurePower
+P.setWavelength(900)
+```
 
 ## Key Functions:
-constructor(), exportState(), send(), minMaxWavelength(), getWavelength(), measure(), setWavelength(), shutdown()
+constructor(), exportState(), send(), minMaxWavelength(), getWavelength(), measurePower(), measureTemperature; setWavelength(), shutdown()
 
 ## REQUIREMENTS:
-NI_DAQ  (VISA and ICP Interfaces) should be installed.
-MATLAB 2014 or higher.
-MIC_Abstract.m
-MIC_PowerMeter_Abstract.m
+* NI_DAQ  (VISA and ICP Interfaces) should be installed.
+* MATLAB 2014 or higher.
+* MIC_Abstract.m
+* MIC_PowerMeter_Abstract.m
 
 ### CITATION: Mohamadreza Fazel, Lidkelab, 2017.
 

--- a/@MIC_PM100D/Readme.md
+++ b/@MIC_PM100D/Readme.md
@@ -3,7 +3,7 @@
 ## Description
 Controls the [ThorLabs PM100D](https://www.thorlabs.com/newgrouppage9.cfm?objectgroup_id=3341&pn=PM100D) light power meter.
 The class can retrieve the current power and current temperature. 
-The wavelenghth of the light can be set programatically, as can the wavelength (within the 400 nm to 1100 nm range).
+The wavelength of the light can be set programatically, as can the wavelength (within the sensor limits).
 The gui shows a movie of the plot of the
 measured power where the shown period can be modified. It also shows
 the current power and the maximum measured power. To run this code

--- a/@MIC_PowerMeter_Abstract/gui.m
+++ b/@MIC_PowerMeter_Abstract/gui.m
@@ -113,8 +113,8 @@ function guiFig=gui(obj)
     obj.GuiFigure.Name = obj.InstrumentName;
     % Move the GUI to the center of the screen.
     movegui(guiFig,'center');
-    % Make the GUI visible.
-    guiFig.Visible = 'on';
+
+
 
 
 

--- a/@MIC_PowerMeter_Abstract/gui.m
+++ b/@MIC_PowerMeter_Abstract/gui.m
@@ -1,165 +1,191 @@
 function guiFig=gui(obj)
-% gui selects a data set from the pop-up menu, then
-% click one of the plot-type push buttons. Clicking the button
-% plots the selected data in the axes.
+    % gui selects a data set from the pop-up menu, then
+    % click one of the plot-type push buttons. Clicking the button
+    % plots the selected data in the axes.
 
-%prevent opening more that one gui for an objext.
-if ishandle(obj.GuiFigure)
-    guiFig = obj.GuiFigure;
-    figure(obj.GuiFigure);
-    return
-end
-        %  Create and then hide the GUI as it is being constructed.
-         guiFig = figure('Visible','on','Position',[250,120,1010,790]);
-        % Construct the components.
-        % editable text
-         hedit0 = uicontrol('Style','edit','Position',[175,730,200,45],'FontSize',20,'FontWeight','bold');
-         % static text
-         htext0 = uicontrol('Style','text','String','Current',...
-                   'Position',[100,720,70,45],'FontSize',12);
-         %static text
-         htext00 = uicontrol('Style','text','String','mW',...
-                   'Position',[380,720,30,45],'FontSize',12);      
-         %editable text      
-         hedit01 = uicontrol('Style','edit','Position',[510,730,200,45],'FontSize',20,'FontWeight','bold');
-         %static text
-         htext01 = uicontrol('Style','text','String','Max',...
-                   'Position',[450,720,50,45],'FontSize',12); 
-         %editable text      
-         htext011 = uicontrol('Style','text','String','mW',...
-                   'Position',[715,720,30,45],'FontSize',12); 
-        % statics text   
-         Htext1String=sprintf('%d<lambda(nm)<%d',obj.Limits(1),obj.Limits(2));
-        % static text
-         htext1 = uicontrol('Style','text','String',Htext1String,...
-                   'Position',[1100,680,200,30],'FontSize',12);
-        %editable text
-         hedit1 = uicontrol('Style','edit','Position',[800,649,150,30],'FontSize',12);
-        %static text 
-         htext2  = uicontrol('Style','text','String','nm',...
-                   'Position',[955,654,25,20],'FontSize',12);       
-        % push botton
-        hStartplot  = uicontrol('Style','pushbutton',...
-                    'String','Start Plot','Position',[800,570,80,30],...
-                    'FontSize',12,'Callback',@startPlotbutton_Callback);
-        % push button        
-        hStopplot  = uicontrol('Style','pushbutton',...
-                    'String','Stop Plot','Position',[890,570,80,30],...
-                    'FontSize',12,'Callback',@stopPlotbutton_Callback);
-        % editable text        
-        hedit3 = uicontrol('Style','edit','Position',[890,530,80,30],'FontSize',12);
-        % static text
-        htext3  = uicontrol('Style','text','String','T(S)',...
-                   'Position',[815,530,50,25],'FontSize',12); 
-        % push button        
-        hget  = uicontrol('Style','pushbutton',...
-                    'String','Get','Position',[473,460,175,30], ...
-                    'FontSize',12,'Callback',{@getbutton_Callback});
-        % editable       
-        hedit2 = uicontrol('Style','edit','Position',[800,420,140,30],'FontSize',12);
-        % static text
-        htext4 = uicontrol('Style','text','String','mW','Position',[940,415,40,30],'FontSize',12);
-        % popup menu 
-        hpopup = uicontrol('Style','popupmenu',...
-                  'String',{'Power(mW)','Temp(C)'},...
-                  'Position',[815,350,140,30],...
-                  'FontSize',12,'Callback',@popup_menu_Callback);
-                
-       %axes
-       ha = axes('Units','pixels','Position',[70,60,700,650]);
-       xlabel('Time(S)')
-       ylabel('Power(log(mW))')
-       % set logarithmic scale for the vertical axis.
-       set(gca,'yscale','log','ylim',[0.001 1000]);
-       %components alignment except axes
-       align([hget,htext1],'Center','None');
-       %Make the GUI visible.
-       guiFig.Visible = 'on';
-       
-       set([guiFig,hget,hStartplot,htext1],'Units','normalized');
-       %getting the current wavelength to be displayed on gui.
-       getWavelength(obj);
-       %WL = sprintf('%0.5f',str2double(obj.Lambda));
-       set(hedit1,'String',obj.Lambda);       
-       %measuring the current power.
-       obj.Ask='power';
-       OutPower=measure(obj);
-       StrPow = sprintf('%0.5f',OutPower);
-       set(hedit2,'String',StrPow);
-       %default period is 10 s.
-       set(hedit3,'String',10);
-       set(hedit0,'String',StrPow);
-       
-       %popup menu
-       function popup_menu_Callback(source,eventdata)  
-          % when user select to measure either power or temp this function
-          % is called and it assign the specified string to thhe property
-          % Ask. Moreover, it sets the labels for the figure. 
-          str = source.String;
-          val = source.Value;
-          % Set current data to the selected data set.
-          switch str{val}
-          case 'Power(W)' % User selects Power.
-             obj.Ask = 'power';    
-             ylabel('Power(\mu W)')
-             ylim([0.001 1000])
-             htext00.String='mW';
-             htext011.String='mW';
-             htext4.String='mW';
-          case 'Temp(C)' % User selects Temp.
-             obj.Ask = 'temp';
-             ylabel('Temp')
-             htext00.String = 'C';
-             htext011.String='C';
-             htext4.String='C';
-          end
-       end                                                                                                                                                           
-       % specified plot type.
-       function getbutton_Callback(source,eventdata) 
-       % Display get plot of the currently selected data.
-            obj.Lambda = str2double(get(hedit1,'String'));
-            
-            if obj.Lambda > obj.Limits(2)
-                error('Wavelength cannot be larger than 1100 nm.')
-            elseif obj.Lambda < obj.Limits(1)
-                error('Wavelength cannot be smaller than 400 nm.')
-            end
-               
-            obj.setWavelength();
-            OutPT=obj.measure();
-            StrPow = sprintf('%0.5f',OutPT);
-            set(hedit2,'String',StrPow);
-       end
+    %prevent opening more that one gui for an objext.
+    if ishandle(obj.GuiFigure)
+        guiFig = obj.GuiFigure;
+        figure(obj.GuiFigure);
+        return
+    end
 
-       function startPlotbutton_Callback(source,eventdata) 
-       % Called when the 'Start plot' button is pushed.    
-       % Display plot of the currently selected data.
-            obj.Stop = 0;
-            %obj.Specify = 'Wavelength';
-            obj.Lambda = str2double(get(hedit1,'String'));
-            
-            if obj.Lambda > 1100
-                error('Wavelength cannot be larger than 1100 nm.')
-            elseif obj.Lambda < 400
-                error('Wavelength cannot be smaller than 400 nm.')
-            end
-            %setting the wavelength to the wavelength in the prompt.
-            obj.setWavelength();
-            %reading the time period from gui.
-            obj.T = str2double(get(hedit3,'String'));
-            %plot measured temperature or power.
-            obj.guiPlot(hedit0,hedit01);
+    %  Create and then hide the GUI as it is being constructed.
+    guiFig = figure('Visible','on','Position',[250,120,1010,790]);
+
+    % Construct the components.
+    % editable text
+     hedit0 = uicontrol('Style','edit','Position',[175,730,200,45],'FontSize',20,'FontWeight','bold');
+     % static text
+     htext0 = uicontrol('Style','text','String','Current',...
+               'Position',[100,720,70,45],'FontSize',12);
+     %static text
+     htext00 = uicontrol('Style','text','String','mW',...
+               'Position',[380,720,30,45],'FontSize',12);
+     %editable text
+     hedit01 = uicontrol('Style','edit','Position',[510,730,200,45],'FontSize',20,'FontWeight','bold');
+     %static text
+     htext01 = uicontrol('Style','text','String','Max',...
+               'Position',[450,720,50,45],'FontSize',12);
+     %editable text
+     htext011 = uicontrol('Style','text','String','mW',...
+               'Position',[715,720,30,45],'FontSize',12);
+    % statics text
+    Htext1String=sprintf('%d<lambda(nm)<%d',obj.Limits(1),obj.Limits(2));
+
+    % static text
+    htext1 = uicontrol('Style','text','String',Htext1String,...
+               'Position',[1100,680,200,30],'FontSize',12);
+
+    %editable text
+    hedit1 = uicontrol('Style','edit','Position',[800,649,150,30],'FontSize',12);
+
+    %static text
+    htext2  = uicontrol('Style','text','String','nm',...
+               'Position',[955,654,25,20],'FontSize',12);
+    % push botton
+    hStartplot  = uicontrol('Style','pushbutton',...
+                'String','Start Plot','Position',[800,570,80,30],...
+                'FontSize',12,'Callback',@startPlotbutton_Callback);
+
+    % push button
+    hStopplot  = uicontrol('Style','pushbutton',...
+                'String','Stop Plot','Position',[890,570,80,30],...
+                'FontSize',12,'Callback',@stopPlotbutton_Callback);
+
+    % editable text
+    hedit3 = uicontrol('Style','edit','Position',[890,530,80,30],'FontSize',12);
+
+    % static text
+    htext3  = uicontrol('Style','text','String','T(S)',...
+               'Position',[815,530,50,25],'FontSize',12);
+    % push button
+    hget  = uicontrol('Style','pushbutton',...
+                'String','Get','Position',[473,460,175,30], ...
+                'FontSize',12,'Callback',{@getbutton_Callback});
+    % editable
+    hedit2 = uicontrol('Style','edit','Position',[800,420,140,30],'FontSize',12);
+
+    % static text
+    htext4 = uicontrol('Style','text','String','mW','Position',[940,415,40,30],'FontSize',12);
+
+    % popup menu
+    hpopup = uicontrol('Style','popupmenu',...
+              'String',{'Power(mW)','Temp(C)'},...
+              'Position',[815,350,140,30],...
+              'FontSize',12,'Callback',@popup_menu_Callback);
+
+    %axes
+    ha = axes('Units','pixels','Position',[70,60,700,650]);
+    xlabel('Time(S)')
+    ylabel('Power(log(mW))')
+
+    % set logarithmic scale for the vertical axis.
+    set(gca,'yscale','log','ylim',[0.001 1000]);
+
+    %components alignment except axes
+    align([hget,htext1],'Center','None');
+
+    %Make the GUI visible.
+    guiFig.Visible = 'on';
+    set([guiFig,hget,hStartplot,htext1],'Units','normalized');
+
+    %getting the current wavelength to be displayed on gui.
+    getWavelength(obj);
+
+    %WL = sprintf('%0.5f',str2double(obj.Lambda));
+    set(hedit1,'String',obj.Lambda);
+
+    %measuring the current power.
+    obj.Ask='power';
+    OutPower=measure(obj);
+    StrPow = sprintf('%0.5f',OutPower);
+    set(hedit2,'String',StrPow);
+
+    %default period is 10 s.
+    set(hedit3,'String',10);
+    set(hedit0,'String',StrPow);
+
+
+
+    % Assign the GUI a name to appear in the window title.
+    obj.GuiFigure = guiFig;
+    obj.GuiFigure.Name = obj.InstrumentName;
+    % Move the GUI to the center of the screen.
+    movegui(guiFig,'center');
+    % Make the GUI visible.
+    guiFig.Visible = 'on';
+
+
+
+
+    % Callback functions follow
+    function popup_menu_Callback(source,eventdata)
+       % popup menu
+       %
+       % when user select to measure either power or temp this function
+       % is called and it assign the specified string to thhe property
+       % Ask. Moreover, it sets the labels for the figure.
+       str = source.String;
+       val = source.Value;
+       % Set current data to the selected data set.
+       switch str{val}
+       case 'Power(W)' % User selects Power.
+          obj.Ask = 'power';
+          ylabel('Power(\mu W)')
+          ylim([0.001 1000])
+          htext00.String='mW';
+          htext011.String='mW';
+          htext4.String='mW';
+       case 'Temp(C)' % User selects Temp.
+          obj.Ask = 'temp';
+          ylabel('Temp')
+          htext00.String = 'C';
+          htext011.String='C';
+          htext4.String='C';
        end
-       
-       function stopPlotbutton_Callback(source,eventdata)
-           %Called when the 'Stop button' is pushed.
-           obj.Stop = 1;
-       end
-       % Assign the GUI a name to appear in the window title.
-       obj.GuiFigure = guiFig;
-       obj.GuiFigure.Name = obj.InstrumentName;
-       % Move the GUI to the center of the screen.
-       movegui(guiFig,'center');
-       % Make the GUI visible.
-       guiFig.Visible = 'on';
-end
+    end % popup_menu_Callback
+
+
+    function getbutton_Callback(source,eventdata)
+    % specified plot type.
+    %
+    % Display get plot of the currently selected data.
+         obj.Lambda = str2double(get(hedit1,'String'));
+         if obj.Lambda > obj.Limits(2)
+             error('Wavelength cannot be larger than 1100 nm.')
+         elseif obj.Lambda < obj.Limits(1)
+             error('Wavelength cannot be smaller than 400 nm.')
+         end
+         obj.setWavelength();
+         OutPT=obj.measure();
+         StrPow = sprintf('%0.5f',OutPT);
+         set(hedit2,'String',StrPow);
+    end % getbutton_Callback
+
+    function startPlotbutton_Callback(source,eventdata)
+        % Called when the 'Start plot' button is pushed.
+        % Display plot of the currently selected data.
+
+        obj.Stop = 0;
+        %obj.Specify = 'Wavelength';
+        obj.Lambda = str2double(get(hedit1,'String'));
+        if obj.Lambda > 1100
+            error('Wavelength cannot be larger than 1100 nm.')
+        elseif obj.Lambda < 400
+            error('Wavelength cannot be smaller than 400 nm.')
+        end
+        %setting the wavelength to the wavelength in the prompt.
+        obj.setWavelength();
+        %reading the time period from gui.
+        obj.T = str2double(get(hedit3,'String'));
+        %plot measured temperature or power.
+        obj.guiPlot(hedit0,hedit01);
+    end % startPlotbutton_Callback
+
+    function stopPlotbutton_Callback(source,eventdata)
+        %Called when the 'Stop button' is pushed.
+        obj.Stop = 1;
+    end % stopPlotbutton_Callback
+
+end % gui

--- a/@MIC_PowerMeter_Abstract/gui.m
+++ b/@MIC_PowerMeter_Abstract/gui.m
@@ -91,14 +91,13 @@ function guiFig=gui(obj)
     set([guiFig,hget,hStartplot,htext1],'Units','normalized');
 
     %getting the current wavelength to be displayed on gui.
-    getWavelength(obj);
+    obj.getWavelength;
 
     %WL = sprintf('%0.5f',str2double(obj.Lambda));
     set(hedit1,'String',obj.Lambda);
 
     %measuring the current power.
-    obj.Ask='power';
-    OutPower=measure(obj);
+    OutPower=obj.measurePower;
     StrPow = sprintf('%0.5f',OutPower);
     set(hedit2,'String',StrPow);
 
@@ -113,10 +112,6 @@ function guiFig=gui(obj)
     obj.GuiFigure.Name = obj.InstrumentName;
     % Move the GUI to the center of the screen.
     movegui(guiFig,'center');
-
-
-
-
 
 
     % Callback functions follow

--- a/@MIC_PowerMeter_Abstract/gui.m
+++ b/@MIC_PowerMeter_Abstract/gui.m
@@ -119,7 +119,7 @@ function guiFig=gui(obj)
        % popup menu
        %
        % when user select to measure either power or temp this function
-       % is called and it assign the specified string to thhe property
+       % is called and it assign the specified string to the property
        % Ask. Moreover, it sets the labels for the figure.
        str = source.String;
        val = source.Value;


### PR DESCRIPTION
If the `InstrumentName` property contained a non-word character like a space then it can not be used to create a variable in the base workspace via the `autoName` method. Add a regular expression to remove all non-word characters when building the variable name. 