### PR TITLE
update unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,10 +131,8 @@ Each instrument will be controlled by its own drivers, which must be installed o
 Similarly, the `MCLMicroDrive` class controls the Mad City Labs Micro Stage and requires the `MicroDrive.dll` dynamic-link library. The first time this class is used on a given computer, the user will be prompted to select the location of `MicroDrive.dll`. On a Windows machine, this is typically placed by default in `C:\Program Files\Mad City Labs\MicroDrive\MicroDrive.dll` during the installation process (installation files provided by MCL).
 
 ## Testing
-[runtests](src/runtests.m) tests the functionality of the
-simulated classes, which in turn tests the various abstract classes the
-simulated classes are based on.  This is done automatically on a push or
-pull request to main.
+See [tests](tests) folder for unit tests of simulated classes, which in turn tests the various abstract classes the
+simulated classes are based on.  This is done automatically on a push or pull request to main.
 
 ## Top-level files and directories
 name | description

--- a/tests/simulated_tests.m
+++ b/tests/simulated_tests.m
@@ -1,10 +1,10 @@
-classdef runtests < matlab.unittest.TestCase
+classdef simulated_tests < matlab.unittest.TestCase
 
 % Run various tests on the core abstract functionality of MIC.
 
 % In the MATLAB unittest context, run in the following manner:
 %    testCase = runtests
-%    results = testCase.run
+
 
 methods (Test)
 


### PR DESCRIPTION
Fixes for:

* MATLAB has a command called `runtests` with which your test class name clashed. Fixed. 
* The test class should also not be in the main code directory because it is not typically called by the user and so should not be in the path.  I have moved it into a directory called tests. 