### PR TITLE
Fix DCAM4Camera timeout for long acquisitions

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,5 +1,5 @@
 {
-	"version": "v1.0.0",
+	"version": "v1.0.1",
 	"title": "A MATLAB-based Instrument Control (MIC) package for fluorescence imaging",
 	"description": "This MATLAB-based Instrument Control (MIC) is a software package designed to facilitate data collection for custom-built microscopes with an emphasis on single molecule localization microscopy (SMLM) and single particle tracking (SPT).",
 	"keywords": [

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -48,9 +48,9 @@ references:
         orcid: 0000-0002-9328-4318
         affiliation: "Department of Physics and Astronomy, University of New Mexico, Albuquerque, New Mexico, USA"
   title: "A MATLAB-based Instrument Control (MIC) package for fluorescence imaging"
-  version: 1.0.0
+  version: 1.0.1
   doi: 10.5281/zenodo.14680987
-  date-released: 2025-01-17
+  date-released: 2026-04-02
   keywords:
     - "MATLAB"
     - "instrument control"

--- a/src/+mic/+camera/@DCAM4Camera/DCAM4Camera.m
+++ b/src/+mic/+camera/@DCAM4Camera/DCAM4Camera.m
@@ -327,7 +327,7 @@ classdef DCAM4Camera < mic.camera.abstract
         FrameRate;
         TriggerMode;        %   trigger mode for Hamamatsu sCMOS camera
         GuiDialog;
-        Timeout = 10000;        % timeout sent to several DCAM functions (milliseconds)
+        Timeout = 100000;        % timeout sent to several DCAM functions (milliseconds)
         %EventMaskString = 'DCAMWAIT_CAPEVENT_CYCLEEND'; % wait event mask used in DCAM functions (see dcamprop.h DCAMWAIT_EVENT)
         Abortnow;
     end
@@ -359,7 +359,7 @@ classdef DCAM4Camera < mic.camera.abstract
         end
         
         function Image = getlastimage(obj)
-            % Return the last image taken by the camera.
+            % Return the last image taken by the camera
             Image = DCAM4CopyLastFrame(obj.CameraHandle, obj.Timeout);
             Image = reshape(Image, obj.ImageSize(1), obj.ImageSize(2));
         end
@@ -443,7 +443,7 @@ classdef DCAM4Camera < mic.camera.abstract
             % readout.
 
             obj.SequenceCycleTime = obj.getProperty(obj.CameraSetting.INTERNAL_FRAME_INTERVAL.idprop);
-            obj.Timeout = 10000+obj.SequenceCycleTime*1e3;
+            obj.Timeout = 100000+obj.SequenceCycleTime*1e3;
             obj.FrameRate = 1/obj.SequenceCycleTime;
             status=obj.HtsuGetStatus;
             if strcmp(status,'Ready')
@@ -752,7 +752,7 @@ classdef DCAM4Camera < mic.camera.abstract
         function out=finishTriggeredCapture(obj,numFrames)
 %             obj.abort();
             imgall = DCAM4CopyFrames(obj.CameraHandle, numFrames, ...
-                obj.SequenceCycleTime*numFrames);
+                obj.Timeout);
             out=reshape(imgall,obj.ImageSize(1),obj.ImageSize(2),numFrames);
             
             % set Trigger mode back to Internal so data can be captured


### PR DESCRIPTION
## Summary
- Increase default `Timeout` from 10s to 100s to prevent timeouts on long acquisitions
- Fix `finishTriggeredCapture` to use `obj.Timeout` instead of `obj.SequenceCycleTime * numFrames`, which was too short for slow frame rates or large frame counts
- Candidate for v1.0.1 patch release

## Test plan
- [ ] Run a long acquisition (>10s total) and verify no timeout errors
- [ ] Test triggered capture mode with slow frame rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)